### PR TITLE
Update CI version matrix

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -7,10 +7,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: 1.10.x
-            otp: 22.x
           - elixir: 1.11.x
             otp: 23.x
+          - elixir: 1.12.x
+            otp: 24.x
+          - elixir: 1.13.x
+            otp: 25.x
             check_formatted: true
             check_style: true
 


### PR DESCRIPTION
Now that elixir 1.13.x and OTP/25 are available, update the test version
matrix to support the last 3 major revisions of each one.