### PR TITLE
Apply mix format and update query test for CI matrix

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -15,6 +15,7 @@ jobs:
             otp: 25.x
             check_formatted: true
             check_style: true
+            run_latest: true
 
     services:
       postgres:
@@ -41,8 +42,15 @@ jobs:
         run: mix credo --format flycheck
       - name: Compile project
         run: mix compile --warnings-as-errors
+      - name: Run tests for older versions
+        if: false == matrix.run_latest
+        run: mix test --cover --exclude skip_before:1.13
+        env:
+          DB_HOST: localhost
+          DB_PORT: ${{ job.services.postgres.ports[5432] }}
       - name: Run tests
-        run: mix test  --cover
+        if: matrix.run_latest
+        run: mix test --cover
         env:
           DB_HOST: localhost
           DB_PORT: ${{ job.services.postgres.ports[5432] }}

--- a/lib/quarto/cursor_value.ex
+++ b/lib/quarto/cursor_value.ex
@@ -19,9 +19,7 @@ defmodule Quarto.CursorValue do
   defp get_cursor_value({field, {position, _}}, entry, queryable) do
     case chase_binding(queryable, position) do
       nil ->
-        raise "Could not find a binding in position #{position} in assocs #{
-                inspect(queryable.assocs)
-              } or in aliases #{inspect(queryable.aliases)}"
+        raise "Could not find a binding in position #{position} in assocs #{inspect(queryable.assocs)} or in aliases #{inspect(queryable.aliases)}"
 
       key ->
         key = key |> Enum.reverse() |> Enum.map(&Access.key/1)

--- a/test/quarto_test.exs
+++ b/test/quarto_test.exs
@@ -654,6 +654,7 @@ defmodule QuartoTest do
                inspect(queryable)
     end
 
+    @tag skip_before: "1.13"
     test "add coalesces in WHERE == clause when custom coalesce function returns nil for multiple sort_fields" do
       coalesce = fn field, _position, _value ->
         case field do
@@ -671,12 +672,10 @@ defmodule QuartoTest do
 
       assert_receive({:query, queryable})
 
-      # The output of inspect/1 differs from elixir 1.12 to elixir 1.13,
-      # so we need to accomodate the minor differences.
-      assert inspect(queryable) in [
-               "#Ecto.Query<from p0 in Quarto.Post, where: (coalesce(p0.position, ^100) == ^3 and (coalesce(p0.id, ^10) > ^10 and ^true)) or\n  (coalesce(p0.position, ^100) < ^3 and ^true and ^true), order_by: [desc: coalesce(p0.position, ^100), asc: coalesce(p0.id, ^10)], limit: ^6>",
-               "#Ecto.Query<from p0 in Quarto.Post, where: coalesce(p0.position, ^100) == ^3 and (coalesce(p0.id, ^10) > ^10 and ^true) or coalesce(p0.position, ^100) < ^3 and ^true and ^true, order_by: [desc: coalesce(p0.position, ^100), asc: coalesce(p0.id, ^10)], limit: ^6>"
-             ]
+      assert """
+             #Ecto.Query<from p0 in Quarto.Post, where: (coalesce(p0.position, ^100) == ^3 and (coalesce(p0.id, ^10) > ^10 and ^true)) or
+               (coalesce(p0.position, ^100) < ^3 and ^true and ^true), order_by: [desc: coalesce(p0.position, ^100), asc: coalesce(p0.id, ^10)], limit: ^6>
+             """ == inspect(queryable) <> "\n"
     end
   end
 

--- a/test/quarto_test.exs
+++ b/test/quarto_test.exs
@@ -671,10 +671,8 @@ defmodule QuartoTest do
 
       assert_receive({:query, queryable})
 
-      assert """
-             #Ecto.Query<from p0 in Quarto.Post, where: (coalesce(p0.position, ^100) == ^3 and (coalesce(p0.id, ^10) > ^10 and ^true)) or
-               (coalesce(p0.position, ^100) < ^3 and ^true and ^true), order_by: [desc: coalesce(p0.position, ^100), asc: coalesce(p0.id, ^10)], limit: ^6>
-             """ == inspect(queryable) <> "\n"
+      assert "#Ecto.Query<from p0 in Quarto.Post, where: (coalesce(p0.position, ^100) == ^3 and (coalesce(p0.id, ^10) > ^10 and ^true)) or\n  (coalesce(p0.position, ^100) < ^3 and ^true and ^true), order_by: [desc: coalesce(p0.position, ^100), asc: coalesce(p0.id, ^10)], limit: ^6>" ==
+               inspect(queryable, pretty: false)
     end
   end
 

--- a/test/quarto_test.exs
+++ b/test/quarto_test.exs
@@ -671,8 +671,12 @@ defmodule QuartoTest do
 
       assert_receive({:query, queryable})
 
-      assert "#Ecto.Query<from p0 in Quarto.Post, where: (coalesce(p0.position, ^100) == ^3 and (coalesce(p0.id, ^10) > ^10 and ^true)) or\n  (coalesce(p0.position, ^100) < ^3 and ^true and ^true), order_by: [desc: coalesce(p0.position, ^100), asc: coalesce(p0.id, ^10)], limit: ^6>" ==
-               inspect(queryable, pretty: false)
+      # The output of inspect/1 differs from elixir 1.12 to elixir 1.13,
+      # so we need to accomodate the minor differences.
+      assert inspect(queryable) in [
+               "#Ecto.Query<from p0 in Quarto.Post, where: (coalesce(p0.position, ^100) == ^3 and (coalesce(p0.id, ^10) > ^10 and ^true)) or\n  (coalesce(p0.position, ^100) < ^3 and ^true and ^true), order_by: [desc: coalesce(p0.position, ^100), asc: coalesce(p0.id, ^10)], limit: ^6>",
+               "#Ecto.Query<from p0 in Quarto.Post, where: coalesce(p0.position, ^100) == ^3 and (coalesce(p0.id, ^10) > ^10 and ^true) or coalesce(p0.position, ^100) < ^3 and ^true and ^true, order_by: [desc: coalesce(p0.position, ^100), asc: coalesce(p0.id, ^10)], limit: ^6>"
+             ]
     end
   end
 


### PR DESCRIPTION
In order to maintain consistent code formatting, apply the outstanding
change from `mix format`. This should fix the failing format step in CI.